### PR TITLE
linker: Fix memory leak for reserved memory

### DIFF
--- a/linker/linker_phdr.cpp
+++ b/linker/linker_phdr.cpp
@@ -173,7 +173,8 @@ bool ElfReader::Load(address_space_params* address_space) {
   if (did_load_) {
     return true;
   }
-  if (ReserveAddressSpace(address_space) && LoadSegments() && FindPhdr() &&
+  bool reserveSuccess = ReserveAddressSpace(address_space);
+  if (reserveSuccess && LoadSegments() && FindPhdr() &&
       FindGnuPropertySection()) {
     did_load_ = true;
 #if defined(__aarch64__)
@@ -183,6 +184,13 @@ bool ElfReader::Load(address_space_params* address_space) {
                                                &note_gnu_property_) == 0);
     }
 #endif
+  }
+  if (reserveSuccess && !did_load_) {
+    if (load_start_ != nullptr && load_size_ != 0) {
+      if (!mapped_by_caller_) {
+        munmap(load_start_, load_size_);
+      }
+    }
   }
 
   return did_load_;


### PR DESCRIPTION
When loading a dynamic library, reserved memory is successful, but fail in other steps, such as loading segments, which will generate a memory leak. Because the reserved memory is not released in time.

Bug: https://issuetracker.google.com/issues/263713888

Change-Id: I556ee02e37db5259df0b6c7178cd9a076dab9725